### PR TITLE
rails-i18nをインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'pry-rails'
+gem 'rails-i18n'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.6)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.1.6)
       actionpack (= 6.1.6)
       activesupport (= 6.1.6)
@@ -281,6 +284,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.6)
+  rails-i18n
   rspec-rails
   rubocop (~> 1.29)
   rubocop-performance

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,9 @@ module Mypalette
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
 

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,3 @@
+ja:
+	activerecord:
+	 models:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,2 @@
+ja:
+	defaults:


### PR DESCRIPTION
closes #7 

rails-i18nをインストールして、日本語化の対応を行いました。
また、複数のlocaleファイルが読み込まれるようにconfig/application.rbでパスを通しました。