### PR TITLE
Palettesテーブルにユーザー情報を保存できるよう実装

### DIFF
--- a/app/controllers/palettes_controller.rb
+++ b/app/controllers/palettes_controller.rb
@@ -4,7 +4,7 @@ class PalettesController < ApplicationController
   end
 
   def create
-    @palette = Palette.new(palette_params)
+    @palette = current_user.palettes.new(palette_params)
     if @palette.save
       flash[:success] = "カラー作成成功しました"
       redirect_to root_path

--- a/app/models/palette.rb
+++ b/app/models/palette.rb
@@ -1,4 +1,7 @@
 class Palette < ApplicationRecord
+
+  belongs_to :user
+
   with_options presence: true do
     validates :main
     validates :sub

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  has_many :palettes, dependent: :destroy
+
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }

--- a/db/migrate/20221130103542_add_user_to_palettes.rb
+++ b/db/migrate/20221130103542_add_user_to_palettes.rb
@@ -1,0 +1,4 @@
+class AddUserToPalettes < ActiveRecord::Migration[6.1]
+  def change
+  end
+end

--- a/db/migrate/20221130103542_add_user_to_palettes.rb
+++ b/db/migrate/20221130103542_add_user_to_palettes.rb
@@ -1,4 +1,5 @@
 class AddUserToPalettes < ActiveRecord::Migration[6.1]
   def change
+    add_reference :palettes, :user, null: false, foreign_key: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_28_051728) do
+ActiveRecord::Schema.define(version: 2022_11_30_103542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 2022_11_28_051728) do
     t.string "body", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_palettes_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -40,4 +42,5 @@ ActiveRecord::Schema.define(version: 2022_11_28_051728) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
+  add_foreign_key "palettes", "users"
 end


### PR DESCRIPTION
Palettesテーブルにユーザー情報を保存できるよう実装しました。

- Palettesテーブルにuser_idの外部キーを持ったカラムを追加
- UserモデルにPalettesモデルとのアソシエーションを定義
- PalettesモデルにUserモデルとのアソシエーションを定義
- ログインしているユーザー情報をPalettesテーブルに保存できるようにpalettesコントローラへコード追加