### PR TITLE
カラーパレットの表示/非表示・カラーサンプルコードの表示/非表示を実装

### DIFF
--- a/app/assets/stylesheets/color_picker.css.erb
+++ b/app/assets/stylesheets/color_picker.css.erb
@@ -22,7 +22,7 @@
 }
 @media screen and (max-width:355px) {
   .colorinput {
-    width: 20px;
-    height: 20px;
+    width: 30px;
+    height: 30px;
   }
 }

--- a/app/controllers/admin/colors_controller.rb
+++ b/app/controllers/admin/colors_controller.rb
@@ -1,4 +1,6 @@
 class Admin::ColorsController < Admin::BaseController
+  layout 'admin/layouts/admin_colorless'
+
   def index
     @palettes = Palette.includes(:user)
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,5 @@
 class Admin::UsersController < Admin::BaseController
+  layout 'admin/layouts/admin_colorless'
   def index
     @users = User.all
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,6 @@
 class Admin::UsersController < Admin::BaseController
   layout 'admin/layouts/admin_colorless'
+
   def index
     @users = User.all
   end

--- a/app/controllers/mypage/colors_controller.rb
+++ b/app/controllers/mypage/colors_controller.rb
@@ -1,4 +1,6 @@
 class Mypage::ColorsController < ApplicationController
+  layout 'layouts/colorless'
+
   def index
     @palettes = current_user.palettes
   end

--- a/app/controllers/mypage/profiles_controller.rb
+++ b/app/controllers/mypage/profiles_controller.rb
@@ -1,4 +1,6 @@
 class Mypage::ProfilesController < ApplicationController
+  layout 'layouts/colorless'
+
   def show
     @user = User.find(current_user.id)
   end

--- a/app/controllers/palettes_controller.rb
+++ b/app/controllers/palettes_controller.rb
@@ -1,4 +1,6 @@
 class PalettesController < ApplicationController
+  skip_before_action :require_login, only: %i[new]
+
   def new
     @palette = Palette.new
   end

--- a/app/controllers/palettes_controller.rb
+++ b/app/controllers/palettes_controller.rb
@@ -9,7 +9,7 @@ class PalettesController < ApplicationController
     @palette = current_user.palettes.new(palette_params)
     if @palette.save
       flash[:success] = "カラー作成成功しました"
-      redirect_to root_path
+      redirect_to palette_path(@palette)
     else
       flash.now[:danger] = "カラー作成失敗しました"
       render :new

--- a/app/views/admin/colors/edit.html.erb
+++ b/app/views/admin/colors/edit.html.erb
@@ -44,11 +44,9 @@
       </div>
     </div>
 
-    <% if %>
-      <div class="px-5 my-auto">
-        <%= f.submit %>
+      <div class="text-center my-auto">
+      <%= f.submit '更新', class: "bg-green-400 hover:bg-green-300 text-white rounded px-3 py-2 my-1" %>
       </div>
-    <% end %>
 
   </div>
 <% end %>

--- a/app/views/admin/colors/index.html.erb
+++ b/app/views/admin/colors/index.html.erb
@@ -1,48 +1,5 @@
 <div class="my-5">
   <% @palettes.each do |palette| %>
-    <div class="flex md:justify-between">
-
-      <div class="px-1 my-auto">
-        <%= palette.user.first_name %>
-      </div>
-
-      <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
-        <div class="flex ">
-          <div class="px-1 my-auto w-5/6">
-            <%= palette.main %>
-          </div>
-          <div>
-            <input type="color" class="main-color colorinput my-auto" value=<%= palette.main %> disabled='true' %>
-          </div>
-        </div>
-      </div>
-
-      <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
-        <div class="flex ">
-          <div class="px-1 my-auto w-5/6">
-            <%= palette.sub %>
-          </div>
-          <div>
-            <input type="color"class="sub-color colorinput my-auto" value=<%= palette.sub %> disabled='true' %>
-          </div>
-        </div>
-      </div>
-
-      <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
-        <div class="flex ">
-          <div class="px-1 my-auto w-5/6">
-            <%= palette.body %>
-          </div>
-          <div>
-            <input type="color" class="body-color colorinput my-auto" value=<%= palette.body %> disabled='true' %>
-          </div>
-        </div>
-      </div>
-
-      <%= link_to "編集", edit_admin_color_path(palette) %>
-      <%= link_to "削除", admin_color_path(palette), method: :delete, data: { confirm: "削除してもよろしいですか？" } %>
-
-    </div>
-
+    <%= render partial: 'shared/unablecolor', locals: {palette: palette} %>
   <% end %>
 </div>

--- a/app/views/admin/colors/index.html.erb
+++ b/app/views/admin/colors/index.html.erb
@@ -1,5 +1,11 @@
 <div class="my-5">
   <% @palettes.each do |palette| %>
+    <div>
+      <%= "作成者: " %><%= palette.user.first_name %>
+    </div>
+    <div>
+      <%= "作成日: " %><%= palette.created_at %>
+    </div>
     <%= render partial: 'shared/unablecolor', locals: {palette: palette} %>
   <% end %>
 </div>

--- a/app/views/admin/layouts/admin_colorless.erb
+++ b/app/views/admin/layouts/admin_colorless.erb
@@ -17,7 +17,6 @@
     <div class="container mx-auto px-5 flex justify-center align-center">
       <%= yield %>
     </div>
-  <%= render 'shared/color_sample' %>
   <%= render 'admin/shared/footer' %>
   </body>
 </html>

--- a/app/views/palettes/_form.html.erb
+++ b/app/views/palettes/_form.html.erb
@@ -44,13 +44,13 @@
       </div>
     </div>
 
-    <% if current_page?(new_palette_path) %>
+    <% if %w[root new_palette].any? {|name| current_page?(send("#{name}_path"))} %>
       <div class="px-5 my-auto">
         <%= f.submit %>
       </div>
     <% end %>
 
-    <% if current_user.own?(palette) %>
+    <% if current_user&.own?(palette) %>
       <%= link_to '削除', palette_path(palette), method: :delete, data: { confirm: "削除しますか?" } %>
     <% end %>
 

--- a/app/views/palettes/_form.html.erb
+++ b/app/views/palettes/_form.html.erb
@@ -2,7 +2,7 @@
   <%= render 'shared/error_messages', object: f.object %>
   <div class="sm:flex justify-between my-5">
 
-    <div class="border m-2 lg:p-4">
+    <div class="border border-b-2 m-2 lg:p-4 bg-gray-50 hover:bg-white">
       <div class="flex ">
         <div class="px-3 my-auto w-4/6">
           <%= f.label :main, "Main Color" %>
@@ -16,7 +16,7 @@
       </div>
     </div>
 
-    <div class="border m-2 lg:p-4">
+    <div class="border border-b-2 m-2 lg:p-4 bg-gray-50 hover:bg-white">
       <div class="flex ">
         <div class="px-3 my-auto w-4/6">
           <%= f.label :sub, "Sub Color" %>
@@ -30,7 +30,7 @@
       </div>
     </div>
 
-    <div class="border m-2 lg:p-4">
+    <div class="border border-b-2 m-2 lg:p-4 bg-gray-50 hover:bg-white">
       <div class="flex ">
         <div class="px-3 my-auto w-4/6">
           <%= f.label :body, "Body Color" %>

--- a/app/views/palettes/_form.html.erb
+++ b/app/views/palettes/_form.html.erb
@@ -45,13 +45,9 @@
     </div>
 
     <% if %w[root new_palette].any? {|name| current_page?(send("#{name}_path"))} %>
-      <div class="px-5 my-auto">
-        <%= f.submit %>
+      <div class="text-center my-auto">
+        <%= f.submit '登録', class: "bg-green-400 hover:bg-green-300 text-white rounded px-3 py-2 my-1" %>
       </div>
-    <% end %>
-
-    <% if current_user&.own?(palette) %>
-      <%= link_to '削除', palette_path(palette), method: :delete, data: { confirm: "削除しますか?" } %>
     <% end %>
 
   </div>

--- a/app/views/palettes/show.html.erb
+++ b/app/views/palettes/show.html.erb
@@ -1,4 +1,4 @@
-<%= render 'form', {palette: @palette} %>
+<%= render partial: 'shared/unablecolor', locals: {palette: @palette} %>
 
 <%= javascript_pack_tag 'color/initial_main_change' %>
 <%= javascript_pack_tag 'color/initial_sub_change' %>

--- a/app/views/shared/_button.html.erb
+++ b/app/views/shared/_button.html.erb
@@ -1,6 +1,6 @@
 <div>
   <% if  %w[admin_colors].any? {|name| current_page?(send("#{name}_path"))} %>
-    <button class="bg-gray-400 hover:bg-gray-300 text-white rounded px-3 py-2">
+    <button class="bg-gray-400 hover:bg-gray-300 text-white rounded px-3 py-2 my-1">
       <%= link_to "編集", edit_admin_color_path(palette) %>
     </button>
     <button class="bg-gray-400 hover:bg-gray-300 text-white rounded px-3 py-2">

--- a/app/views/shared/_button.html.erb
+++ b/app/views/shared/_button.html.erb
@@ -1,0 +1,5 @@
+<% if current_user&.own?(palette) %>
+  <button class="bg-gray-400 hover:bg-gray-300 text-white rounded px-3 py-2">
+    <%= link_to '削除', palette_path(palette), method: :delete, data: { confirm: "削除しますか?" } %>
+  </button>
+<% end %>

--- a/app/views/shared/_button.html.erb
+++ b/app/views/shared/_button.html.erb
@@ -1,5 +1,14 @@
-<% if current_user&.own?(palette) %>
-  <button class="bg-gray-400 hover:bg-gray-300 text-white rounded px-3 py-2">
-    <%= link_to '削除', palette_path(palette), method: :delete, data: { confirm: "削除しますか?" } %>
-  </button>
-<% end %>
+<div>
+  <% if  %w[admin_colors].any? {|name| current_page?(send("#{name}_path"))} %>
+    <button class="bg-gray-400 hover:bg-gray-300 text-white rounded px-3 py-2">
+      <%= link_to "編集", edit_admin_color_path(palette) %>
+    </button>
+    <button class="bg-gray-400 hover:bg-gray-300 text-white rounded px-3 py-2">
+      <%= link_to "削除", admin_color_path(palette), method: :delete, data: { confirm: "削除してもよろしいですか？" } %>
+    </button>
+  <% elsif current_user&.own?(palette) %>
+    <button class="bg-gray-400 hover:bg-gray-300 text-white rounded px-3 py-2">
+      <%= link_to '削除', palette_path(palette), method: :delete, data: { confirm: "削除しますか?" } %>
+    </button>
+  <% end %>
+</div>

--- a/app/views/shared/_button.html.erb
+++ b/app/views/shared/_button.html.erb
@@ -1,13 +1,13 @@
 <div>
   <% if  %w[admin_colors].any? {|name| current_page?(send("#{name}_path"))} %>
-    <button class="bg-gray-400 hover:bg-gray-300 text-white rounded px-3 py-2 my-1">
+    <button class="bg-green-400 hover:bg-green-300 text-white rounded px-3 py-2 my-1">
       <%= link_to "編集", edit_admin_color_path(palette) %>
     </button>
-    <button class="bg-gray-400 hover:bg-gray-300 text-white rounded px-3 py-2">
+    <button class="bg-red-500 hover:bg-red-400 text-white rounded px-3 py-2">
       <%= link_to "削除", admin_color_path(palette), method: :delete, data: { confirm: "削除してもよろしいですか？" } %>
     </button>
   <% elsif current_user&.own?(palette) %>
-    <button class="bg-gray-400 hover:bg-gray-300 text-white rounded px-3 py-2">
+    <button class="bg-red-500 hover:bg-red-400 text-white rounded px-3 py-2">
       <%= link_to '削除', palette_path(palette), method: :delete, data: { confirm: "削除しますか?" } %>
     </button>
   <% end %>

--- a/app/views/shared/_unablecolor.html.erb
+++ b/app/views/shared/_unablecolor.html.erb
@@ -1,39 +1,50 @@
 <div class="flex md:justify-between my-5">
 
   <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
-    <div class="md:flex">
+    <div class="md:flex ">
       <div class="px-1 my-auto w-5/6">
-        <%= palette.main %>
+        Main Color
       </div>
       <div class="text-center">
         <input type="color" class="main-color colorinput my-auto" value=<%= palette.main %> disabled='true' %>
       </div>
     </div>
-  </div>
-
-  <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
-    <div class="md:flex">
-      <div class="px-1 my-auto w-5/6">
-        <%= palette.sub %>
-      </div>
-      <div class="text-center">
-        <input type="color"class="sub-color colorinput my-auto" value=<%= palette.sub %> disabled='true' %>
-      </div>
+    <div class="text-center">
+      <%= palette.main %>
     </div>
   </div>
 
   <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
-    <div class="md:flex">
+    <div class="md:flex ">
       <div class="px-1 my-auto w-5/6">
-        <%= palette.body %>
+        Sub Color
+      </div>
+      <div class="text-center">
+        <input type="color" class="sub-color colorinput my-auto" value=<%= palette.sub %> disabled='true' %>
+      </div>
+    </div>
+    <div class="text-center">
+      <%= palette.sub %>
+    </div>
+  </div>
+
+  <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
+    <div class="md:flex ">
+      <div class="px-1 my-auto w-5/6">
+        Body Color
       </div>
       <div class="text-center">
         <input type="color" class="body-color colorinput my-auto" value=<%= palette.body %> disabled='true' %>
       </div>
     </div>
+    <div class="text-center">
+      <%= palette.body %>
+    </div>
   </div>
 
-</div>
-<div class="my-auto">
-  <%= render partial: 'shared/button', locals: { palette: palette} %>
+
+  <div class="my-auto">
+    <%= render partial: 'shared/button', locals: { palette: palette} %>
+  </div>
+
 </div>

--- a/app/views/shared/_unablecolor.html.erb
+++ b/app/views/shared/_unablecolor.html.erb
@@ -1,0 +1,40 @@
+<div class="flex md:justify-between">
+
+  <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
+    <div class="flex ">
+      <div class="px-1 my-auto w-5/6">
+        <%= palette.main %>
+      </div>
+      <div>
+        <input type="color" class="main-color colorinput my-auto" value=<%= palette.main %> disabled='true' %>
+      </div>
+    </div>
+  </div>
+
+  <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
+    <div class="flex ">
+      <div class="px-1 my-auto w-5/6">
+        <%= palette.sub %>
+      </div>
+      <div>
+        <input type="color"class="sub-color colorinput my-auto" value=<%= palette.sub %> disabled='true' %>
+      </div>
+    </div>
+  </div>
+
+  <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
+    <div class="flex ">
+      <div class="px-1 my-auto w-5/6">
+        <%= palette.body %>
+      </div>
+      <div>
+        <input type="color" class="body-color colorinput my-auto" value=<%= palette.body %> disabled='true' %>
+      </div>
+    </div>
+  </div>
+
+  <% if current_user&.own?(palette) %>
+    <%= link_to '削除', palette_path(palette), method: :delete, data: { confirm: "削除しますか?" } %>
+  <% end %>
+
+</div>

--- a/app/views/shared/_unablecolor.html.erb
+++ b/app/views/shared/_unablecolor.html.erb
@@ -1,6 +1,6 @@
 <div class="flex md:justify-between my-5">
 
-  <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
+  <div class="border sm:m-0 md:m-2 lg:p-4 w-1/4">
     <div class="md:flex ">
       <div class="px-1 my-auto w-5/6">
         Main Color
@@ -14,7 +14,7 @@
     </div>
   </div>
 
-  <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
+  <div class="border sm:m-0 md:m-2 lg:p-4 w-1/4">
     <div class="md:flex ">
       <div class="px-1 my-auto w-5/6">
         Sub Color
@@ -28,7 +28,7 @@
     </div>
   </div>
 
-  <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
+  <div class="border sm:m-0 md:m-2 lg:p-4 w-1/4">
     <div class="md:flex ">
       <div class="px-1 my-auto w-5/6">
         Body Color

--- a/app/views/shared/_unablecolor.html.erb
+++ b/app/views/shared/_unablecolor.html.erb
@@ -35,9 +35,5 @@
 
 </div>
 <div class="my-auto">
-  <% if current_user&.own?(palette) %>
-    <button class="bg-gray-400 hover:bg-gray-300 text-white rounded px-3 py-2">
-      <%= link_to '削除', palette_path(palette), method: :delete, data: { confirm: "削除しますか?" } %>
-    </button>
-  <% end %>
+  <%= render partial: 'shared/button', locals: { palette: palette} %>
 </div>

--- a/app/views/shared/_unablecolor.html.erb
+++ b/app/views/shared/_unablecolor.html.erb
@@ -1,40 +1,43 @@
-<div class="flex md:justify-between">
+<div class="flex md:justify-between my-5">
 
   <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
-    <div class="flex ">
+    <div class="md:flex">
       <div class="px-1 my-auto w-5/6">
         <%= palette.main %>
       </div>
-      <div>
+      <div class="text-center">
         <input type="color" class="main-color colorinput my-auto" value=<%= palette.main %> disabled='true' %>
       </div>
     </div>
   </div>
 
   <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
-    <div class="flex ">
+    <div class="md:flex">
       <div class="px-1 my-auto w-5/6">
         <%= palette.sub %>
       </div>
-      <div>
+      <div class="text-center">
         <input type="color"class="sub-color colorinput my-auto" value=<%= palette.sub %> disabled='true' %>
       </div>
     </div>
   </div>
 
   <div class="border sm:m-0 md:m-2 lg:p-4 w-2/6">
-    <div class="flex ">
+    <div class="md:flex">
       <div class="px-1 my-auto w-5/6">
         <%= palette.body %>
       </div>
-      <div>
+      <div class="text-center">
         <input type="color" class="body-color colorinput my-auto" value=<%= palette.body %> disabled='true' %>
       </div>
     </div>
   </div>
 
+</div>
+<div class="my-auto">
   <% if current_user&.own?(palette) %>
-    <%= link_to '削除', palette_path(palette), method: :delete, data: { confirm: "削除しますか?" } %>
+    <button class="bg-gray-400 hover:bg-gray-300 text-white rounded px-3 py-2">
+      <%= link_to '削除', palette_path(palette), method: :delete, data: { confirm: "削除しますか?" } %>
+    </button>
   <% end %>
-
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
-  root "static_pages#top"
+  root "palettes#new"
   get "about" => "homes#about"
   get "terms_of_use" => "homes#terms"
   get "privacy_policy" => "homes#policy"


### PR DESCRIPTION
カラーパレットの表示/非表示・カラーサンプルコードの表示/非表示を実装しました。

- rootのランディングページを変更
- コントローラ単位でカラーサンプルコードの表示/非表示の出しわけを実装
- カラーパレットのレイアウトを実装
- 各ボタンのレイアウトを変更