### PR TITLE
Headerとその他サービスの注意事項画面のレイアウト調整

### DIFF
--- a/app/views/homes/policy.html.erb
+++ b/app/views/homes/policy.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full max-w-md mt-10 mb-32">
+<div class="md:w-3/4 my-5 mx-auto">
   <div class="text-center mb-3">
     <h1 class="text-lg font-bold tracking-wider mb-4">プライバシーポリシー</h1>
   </div>

--- a/app/views/homes/terms.html.erb
+++ b/app/views/homes/terms.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full max-w-md mt-10 mb-32">
+<div class="md:w-3/4 my-5 mx-auto">
   <div class="text-center mb-3">
     <h1 class="text-lg font-bold tracking-wider mb-4">利用規約</h1>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,6 +10,10 @@
       <div>
         <%= link_to 'Admin Menu', admin_colors_path, class:"mt-0 mx-1 inline-block text-sm px-4 py-2 leading-none border rounded text-white border-white hover:border-transparent hover:text-yellow-500 hover:bg-white", data: {"turbolinks" => false}  %>
       </div>
+    <% else %>
+     <div>
+        <%= link_to 'All Colors', palettes_path, class:"mt-0 mx-1 inline-block text-sm px-4 py-2 leading-none border rounded text-white border-white hover:border-transparent hover:text-yellow-500 hover:bg-white", data: {"turbolinks" => false}  %>
+      </div>
     <% end %>
     <div>
       <%= link_to 'スキ Colors', mypage_palettes_likes_path, class:"mt-0 mx-1 inline-block text-sm px-4 py-2 leading-none border rounded text-white border-white hover:border-transparent hover:text-yellow-500 hover:bg-white", data: {"turbolinks" => false}  %>


### PR DESCRIPTION
Headerとその他サービスの注意事項画面のレイアウト調整をしました。

- _headerパーシャルに全てのカラーを見れるパーシャルボタンを追加
- 利用規約ページのレイアウトを調整
- プライバシーポリシーページのレイアウトを調整