### PR TITLE
表示する時間のフォーマットを見やすく変更

### DIFF
--- a/app/views/mypage/profiles/show.html.erb
+++ b/app/views/mypage/profiles/show.html.erb
@@ -12,7 +12,7 @@
               登録日
             </div>
             <div>
-              <%= l @user.created_at, format: :short %>
+              <%= l @user.created_at %>
             </div>
           </div>
           <div class="my-7">

--- a/app/views/mypage/shared/_activebutton.html.erb
+++ b/app/views/mypage/shared/_activebutton.html.erb
@@ -1,6 +1,6 @@
 <div class="flex my-5">
   <div class="text-center w-1/2">
-    <%= link_to "My colors", mypage_colors_path, class: "p-1 block #{active_if('mypage/colors')}" %>
+    <%= link_to "My colors", mypage_colors_path, class: "p-1 block #{active_if('mypage/colors')}", data: {"turbolinks" => false} %>
   </div>
   <div class="text-center w-1/2">
     <%= link_to "Profile", mypage_profile_path, class: "p-1 block #{active_if('mypage/profiles')}" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,11 +32,11 @@ module Mypalette
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    # config.i18n.default_locale = :ja
-    # config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
-
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
+
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
 
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  time:
+    formats:
+      default: "%Y/%m/%d"


### PR DESCRIPTION
closes #89 

表示する時間のフォーマットを見やすく変更しました。

- デフォルト言語を日本語に変更
- localファイルの設定読み込みを変更
- 表示形式を変更